### PR TITLE
Allow graceful fallback to non-TLS protocols

### DIFF
--- a/tlsutil/hello.go
+++ b/tlsutil/hello.go
@@ -49,7 +49,7 @@ func PeekClientHello(reader io.Reader) (*tls.ClientHelloInfo, io.Reader, error) 
 	peekedBytes := new(bytes.Buffer)
 	hello, err := ReadClientHello(io.TeeReader(reader, peekedBytes))
 	if err != nil {
-		return nil, nil, err
+		return nil, io.MultiReader(peekedBytes, reader), err
 	}
 	return hello, io.MultiReader(peekedBytes, reader), nil
 }


### PR DESCRIPTION
Bytes are normally consumed irreparably. This change allows to use the multireader even in case of an error, and graceful fallbacks to non-TLS protocols.